### PR TITLE
Updated dependency YahooQuotesApi from 5.5.1 to 5.5.5

### DIFF
--- a/YahooXL/YahooXL.csproj
+++ b/YahooXL/YahooXL.csproj
@@ -23,7 +23,7 @@
 	  <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
 	  <PackageReference Include="Microsoft.Extensions.Logging.EventSource" Version="8.0.0" />
 	  <PackageReference Include="System.Reactive" Version="6.0.0" />
-	  <PackageReference Include="YahooQuotesApi" Version="5.5.1" />
+	  <PackageReference Include="YahooQuotesApi" Version="5.5.5" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
There are no breaking changes from this that I'm aware of, although I didn't test it extensively. It's necessary in order to get it to work for European IP addresses.